### PR TITLE
Drop unused format import

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var fs = require('fs-extra');
 var path = require('path');
 var run = require('electron-installer-run');
 var zipFolder = require('zip-folder');
-var format = require('util').format;
 var series = require('async').series;
 var debug = require('debug')('electron-installer-zip');
 


### PR DESCRIPTION
Just testing node-security fails this as I'd expect it to so https://github.com/mongodb-js/electron-installer-zip/pull/4 can go through if that's how we'd like to proceed.